### PR TITLE
Provide a way to retrieve the internal viewer instance

### DIFF
--- a/src/vue-pannellum.vue
+++ b/src/vue-pannellum.vue
@@ -155,6 +155,9 @@ export default {
       if (yaw != this.yaw) this.$emit('update:yaw', yaw)
       if (pitch != this.pitch) this.$emit('update:pitch', pitch)
     },
+    getViewer () {
+      return this.viewer
+    },
     onMouseUp () {
       if (this.debug) this.info += ' mu'
       this.debounceRotate()


### PR DESCRIPTION
Thanks for creating this component. Was just after a way to retrieve the internal viewer instance so I can call some functions on it such as `resize()` when its container height changes