### PR TITLE
add prop crossOrigin

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ src = {
 - **pitch (number, default: 0)**: The initial pitch position in degrees.
 - **minHfov (number, default: 30)**: The minimum limit of hfov in degrees.
 - **maxHfov (number, default: 120)**: The maximum limit of hfov in degrees.
+- **crossOrigin (string, default: anonymous)**: Specify the type of CORS request used. Can be set to `anonymous` or `use-credentials`
 
 ## Events
 

--- a/src/vue-pannellum.vue
+++ b/src/vue-pannellum.vue
@@ -40,6 +40,7 @@ export default {
     maxHfov: { type: Number, default: 120 },
     yaw: { type: Number, default: 0 },
     pitch: { type: Number, default: 0 },
+    crossOrigin: {type: String, default: 'anonymous' },
   },
   data () {
     return {
@@ -148,6 +149,7 @@ export default {
         pitch: this.pitch,
         minHfov: this.minHfov,
         maxHfov: this.maxHfov,
+        crossOrigin: this.crossOrigin,
         // haov: 149.87,
         // vaov: 54.15,
         ...this.srcOption,


### PR DESCRIPTION
Adds a new prop which allows specifying whether the CORS policy should be set to anonymous or use-credentials.

This change is needed because the request pannellum makes does not normally include cookies in the header. In scenarios where cookies are required (example: putting image assets behind auth), this makes the vue-pannellum library un-usable.

[Pannellum docs on cors](https://pannellum.org/documentation/reference/#crossorigin-string)
[Original issue](https://github.com/mpetroff/pannellum/issues/515)

The pannellum lib defaults to `anonymous`, the same as this proposed change.